### PR TITLE
Fix deploy rollback on error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out
 node_modules
 .vscode/settings.json
+*.vsix

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ If needed (ex: when using a sandbox organization), you can also specify the `log
 }
 ```
 
+By default when deploying a package to your organization it is set to rollback on errors. If you want to disable this feature, add the following line to your configuration:
+
+```json
+{
+  "vsforce.organization.rollbackOnError": false,
+}
+```
+
 When properly configured, a message will appear in the status bar informing you that the extension is logged to your Salesforce organization.
 
 ## Using the commands

--- a/package.json
+++ b/package.json
@@ -154,6 +154,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "If we want to push local changes to Salesforce on save."
+                },
+                "vsforce.options.rollbackOnError": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "If we want a rollback on an error for the deploy (Must be true for production orgs)."
                 }
             }
         }

--- a/src/commands/deployPackageCommand.ts
+++ b/src/commands/deployPackageCommand.ts
@@ -91,9 +91,17 @@ export class DeployPackageCommand implements ICommand {
         this.diags.clear();
         this.handleDeployResponse(result);
       })
-      .catch((reason: string) => {
-        if (reason) {
-          vscode.window.showErrorMessage(reason, { title: 'Show output', action: 'SHOW_OUTPUT' }).then((m) => {
+      .catch((ex: any) => {
+        let message: string;
+        message = `An error occured`;
+        if (ex) {
+          if (ex instanceof String) {
+            message = ex;
+            this.output.appendLine(ex);
+          } else {
+            this.output.appendLine(ex.toString());
+          }
+          vscode.window.showErrorMessage(message, { title: 'Show output', action: 'SHOW_OUTPUT' }).then((m) => {
             if (m.action && m.action === 'SHOW_OUTPUT') {
               this.output.show();
             }

--- a/src/commands/deployPackageCommand.ts
+++ b/src/commands/deployPackageCommand.ts
@@ -115,7 +115,6 @@ export class DeployPackageCommand implements ICommand {
     this.output.appendLine(`Status: ${response.status}`);
     this.output.appendLine('============================\n');
 
-    console.log(response);
     switch (response.status) {
       case DeployStatus[DeployStatus.Failed]: // Failed
       case DeployStatus[DeployStatus.Succeeded]: // Succeeded

--- a/src/commands/deployPackageCommand.ts
+++ b/src/commands/deployPackageCommand.ts
@@ -137,7 +137,6 @@ export class DeployPackageCommand implements ICommand {
   }
 
   private displayDeployResponse(response: any) {
-
     if (response.details.componentSuccesses) {
       // Salesforce doesn't send an array of just 1 element...
       let successes = utils.asArray(response.details.componentSuccesses);

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -351,6 +351,8 @@ export class Connection {
           if (typeof options[prop] !== 'undefined') { deployOpts[prop] = options[prop]; }
         });
 
+        deployOpts.rollbackOnError = Config.getInstance().rollbackOnError;
+
         resolve(conn.jsforceConn.metadata.deploy(zipStream, deployOpts)
           .complete({ details: true }));
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -10,6 +10,7 @@ export class Config extends events.EventEmitter {
   public securityToken: string;
   public customNamespace: string;
   public pushOnSave: boolean;
+  public rollbackOnError: boolean;
 
   public isValid: boolean;
 
@@ -47,6 +48,7 @@ export class Config extends events.EventEmitter {
       Config.getInstance().securityToken = organization.get<string>('securityToken');
       Config.getInstance().customNamespace = organization.get<string>('namespace');
       Config.getInstance().pushOnSave = options.get<boolean>('pushOnSave');
+      Config.getInstance().rollbackOnError = options.get<boolean>('rollbackOnError');
 
       Config.getInstance().isValid = true;
     } else {


### PR DESCRIPTION
Added a new option to control rollbackOnError for package deploys.
This option must be set to true on production organizations, so the default value is true.