### PR TITLE
Fixes typo for the word TABLE

### DIFF
--- a/src/providers/salesforceContentProvider.ts
+++ b/src/providers/salesforceContentProvider.ts
@@ -85,7 +85,7 @@ export class SalesforceContentProvider implements vscode.TextDocumentContentProv
 
               tableResult += '</table>';
 
-              render = render.replace('{{TALBE_RESULT}}', tableResult);
+              render = render.replace('{{TABLE_RESULT}}', tableResult);
             };
 
             resolve(render);


### PR DESCRIPTION
# Fixing typo

It should be `TABLE_RESULT` not `TALBE_RESULT`.


